### PR TITLE
Fix sidebar styling + history.pushState

### DIFF
--- a/homepage/static/homepage/css/main_index.css
+++ b/homepage/static/homepage/css/main_index.css
@@ -792,8 +792,12 @@
   }
   #sidebar > .nav-menu-collapsible > div > ul > li > a {
     display: block;
+    border: 1px solid #2a2a2a;
     padding: 0.35em 0.9em;
     text-decoration: none;
+  }
+  #sidebar > .nav-menu-collapsible > div > ul > li > a.active {
+    border: 1px solid #e77681;
   }
   #sidebar > .nav-menu-collapsible > div > ul > li > a * {
     display: inline;

--- a/homepage/static/homepage/css/main_index.css
+++ b/homepage/static/homepage/css/main_index.css
@@ -510,6 +510,12 @@
   -ms-transition: padding 0.4s ease-in-out, left 0.4s ease-in-out, top 0.4s ease-in-out, width 0.4s ease-in-out, height 0.4s ease-in-out;
   transition: padding 0.4s ease-in-out, left 0.4s ease-in-out, top 0.4s ease-in-out, width 0.4s ease-in-out, height 0.4s ease-in-out;
 }
+.nav-top > .nav-menu-collapsible > div > ul > li > a.topic-link {
+  border: 1px solid #2a2a2a;
+}
+.nav-top > .nav-menu-collapsible > div > ul > li > a.topic-link.active {
+  border: 1px solid #e77681;
+}
 .nav-top.minimized {
   top: 0;
   left: 0;
@@ -790,16 +796,16 @@
   #sidebar > .nav-menu-collapsible > div > ul {
     display: block;
   }
-  #sidebar > .nav-menu-collapsible > div > ul > li > a {
+  #sidebar > .nav-menu-collapsible > div > ul > li > a.topic-link {
     display: block;
     border: 1px solid #2a2a2a;
     padding: 0.35em 0.9em;
     text-decoration: none;
   }
-  #sidebar > .nav-menu-collapsible > div > ul > li > a.active {
+  #sidebar > .nav-menu-collapsible > div > ul > li > a.topic-link.active {
     border: 1px solid #e77681;
   }
-  #sidebar > .nav-menu-collapsible > div > ul > li > a * {
+  #sidebar > .nav-menu-collapsible > div > ul > li > a.topic-link * {
     display: inline;
   }
 }

--- a/homepage/static/homepage/js/navbar.js
+++ b/homepage/static/homepage/js/navbar.js
@@ -74,4 +74,13 @@ $(function () {
     //         ];
     // })();
     // $(".logo svg path").hover(svgHoverFuncs[0], svgHoverFuncs[1]);
+    $("#sidebar .nav-menu-collapsible a.topic-link").each(function () {
+        $(this).click(function () {
+            $("#sidebar .nav-menu-collapsible a.topic-link.active").removeClass("active");
+            let newActive = $(this)
+            let newActiveCategory = newActive.text()
+            $(this).addClass("active");
+            window.history.pushState({category: newActiveCategory}, " - " + newActiveCategory, newActive.attr("data-url"));
+        });
+    });
 });

--- a/homepage/static/homepage/js/navbar.js
+++ b/homepage/static/homepage/js/navbar.js
@@ -74,13 +74,40 @@ $(function () {
     //         ];
     // })();
     // $(".logo svg path").hover(svgHoverFuncs[0], svgHoverFuncs[1]);
+    function setActiveCategory(newActiveDOM) {
+        $("#sidebar .nav-menu-collapsible a.topic-link.active").removeClass("active");
+        if (newActiveDOM) {
+            newActiveDOM.addClass("active");
+        }
+    }
+    let currentActiveDOM = $("#sidebar .nav-menu-collapsible a.topic-link.active");
+    if (currentActiveDOM) {
+        window.history.replaceState({category: currentActiveDOM.text()}, "");
+    } else {
+        window.history.replaceState({category: undefined}, "");
+    }
+    window.onpopstate = function (event) {
+        let serialized_data = event.state;
+        if (serialized_data.category) {
+            document.title = "Pulp Science - " + serialized_data.category;
+        } else {
+            document.title = "Pulp Science";
+        }
+        setActiveCategory(
+            $("#sidebar .nav-menu-collapsible a.topic-link:contains('" + serialized_data.category + "')")
+        );
+    };
     $("#sidebar .nav-menu-collapsible a.topic-link").each(function () {
         $(this).click(function () {
-            $("#sidebar .nav-menu-collapsible a.topic-link.active").removeClass("active");
-            let newActive = $(this)
-            let newActiveCategory = newActive.text()
-            $(this).addClass("active");
-            window.history.pushState({category: newActiveCategory}, " - " + newActiveCategory, newActive.attr("data-url"));
+            let newActive = $(this);
+            let newActiveCategory = newActive.text();
+            setActiveCategory(newActive);
+            window.history.pushState(
+                {category: newActiveCategory},
+                " - " + newActiveCategory,
+                newActive.attr("data-url")
+            );
+            document.title = "Pulp Science - " + newActiveCategory;
         });
     });
 });

--- a/homepage/static/homepage/scss/components/_navbar.scss
+++ b/homepage/static/homepage/scss/components/_navbar.scss
@@ -184,6 +184,14 @@
       //'font-size 0.4s ease-in-out'
     ));
 
+    & > .nav-menu-collapsible > div > ul > li > a.topic-link {
+      border: 1px solid _palette('bg-alt');
+
+      &.active {
+        border: 1px solid darken(_palette('link-hover'), 10%);
+      }
+    }
+
   &.minimized {
     top: 0;
     left: 0;

--- a/homepage/static/homepage/scss/components/_sidebar.scss
+++ b/homepage/static/homepage/scss/components/_sidebar.scss
@@ -44,8 +44,13 @@
         & > li {
           & > a{
             display: block;
+            border: 1px solid _palette('bg-alt');
             padding: _size('padding-btn');
             text-decoration: none;
+
+            &.active {
+              border: 1px solid darken(_palette('link-hover'), 10%);
+            }
 
             & * {
               display: inline;

--- a/homepage/static/homepage/scss/components/_sidebar.scss
+++ b/homepage/static/homepage/scss/components/_sidebar.scss
@@ -42,7 +42,7 @@
       & > ul {
         display: block;
         & > li {
-          & > a{
+          & > a.topic-link {
             display: block;
             border: 1px solid _palette('bg-alt');
             padding: _size('padding-btn');

--- a/homepage/templates/base.html
+++ b/homepage/templates/base.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Pulp Science</title>
+    <title>{{ page_title }}</title>
     <link rel="shortcut icon" type="image/png" href="{% static 'homepage/images/favicon-32x32.png' %}" sizes="32x32"/>
     <link rel="stylesheet" type="text/css" href="{% static 'homepage/css/main_base.css' %}">
     {% block stylesheets %}

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -43,7 +43,9 @@
             <div class="hide">
                 <ul>
                     {% for category in categories %}
-                        <li><a class="topic-link{{ category.add_class }}" href="{{ category.link }}">{{ category.label }}</a></li>
+                        <li><a class="topic-link{{ category.add_class }}" data-url="{{ category.link }}">
+                            {{ category.label }}
+                        </a></li>
                     {% endfor %}
                 <!--
                     <li><a class="topic-link active">Informatics</a></li>

--- a/homepage/tests.py
+++ b/homepage/tests.py
@@ -55,7 +55,7 @@ class TestIndexPage(TestCase):
         response = self.client.get(reverse("homepage:index", kwargs={"active_category": "physics"}))
         self.assertEqual(response.status_code, 200)
         find_physics = (
-            f'<a class="topic-link active" href="'
+            f'<a class="topic-link active" data-url="'
             f'{reverse("homepage:index", kwargs={"active_category": "physics"})}">Physics</a>'
         )
         self.assertContains(response, find_physics, html=True)

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -25,7 +25,10 @@ def index(request, active_category: Optional[Category] = None):
                 "link": reverse("homepage:index", kwargs={"active_category": member.label.lower()}),
             }
         )
+    page_title = "Pulp Science"
+    if active_category is not None:
+        page_title += f" - {active_category.label}"
 
     template_name = "homepage/index.html"
-    context = {"categories": categories}
+    context = {"categories": categories, "page_title": page_title}
     return render(request, template_name, context)


### PR DESCRIPTION
There were some ugly gaps on the sidebar when clicking on different categories. This is now fixed.
Additionally, I added that the page will not reload by clicking on these. Instead, the page make use of `window.history.pushState`.